### PR TITLE
feat: add persistence logging across all service layer (FIX-20260317)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,6 +11,9 @@ COPY requirements.txt /code/
 RUN apt-get update && apt-get install -y curl tree
 RUN pip install --upgrade pip && pip install -r /code/requirements.txt
 
+# Crea los directorios de logs necesarios
+RUN mkdir -p /var/log/samb && chmod 755 /var/log/samb
+
 # Establece el directorio de trabajo
 WORKDIR /code
 

--- a/apis/services/cronjobs/ServicesCronjobs.py
+++ b/apis/services/cronjobs/ServicesCronjobs.py
@@ -7,6 +7,7 @@ import apis.entities.cronjobs.EntityCronjobs as EntityCronjobs
 import apis.repositories.cronjobs.RepositoryCronjobs as RepositoryCronjobs
 
 logger = logging.getLogger('apis.services.cronjobs')
+logger_persistence = logging.getLogger('ServicesPersistence')
 
 class ServicesCronjobs():
 
@@ -22,7 +23,35 @@ class ServicesCronjobs():
 
     def add_repository(self,data):
 
-        return self.repository.add(data)
+        start_time = time.time()
+        result = self.repository.add(data)
+        execution_time = (time.time() - start_time) * 1000
+
+        if result.get('status'):
+            logger_persistence.info(
+                f"💾 ADD PERSISTENCE | "
+                f"Table: samb_cronjobs | "
+                f"Project: {self.entity.get_project_name()} | "
+                f"Method: add_repository | "
+                f"Cronjob ID: {data.get('id', 'N/A')} | "
+                f"API ID: {data.get('id_api', 'N/A')} | "
+                f"Execution Time: {execution_time:.2f}ms | "
+                f"Status: SUCCESS"
+            )
+        else:
+            logger_persistence.error(
+                f"💾 ADD PERSISTENCE | "
+                f"Table: samb_cronjobs | "
+                f"Project: {self.entity.get_project_name()} | "
+                f"Method: add_repository | "
+                f"Cronjob ID: {data.get('id', 'N/A')} | "
+                f"API ID: {data.get('id_api', 'N/A')} | "
+                f"Execution Time: {execution_time:.2f}ms | "
+                f"Status: FAILED | "
+                f"Error: {result.get('msj', 'Unknown error')}"
+            )
+
+        return result
     
     def set_id_cronjobs(self,id_cronjobs):
 
@@ -488,7 +517,33 @@ class ServicesCronjobs():
     
     def set_ejecution_repository(self,data):
 
-        return self.repository.set(data)
+        start_time = time.time()
+        result = self.repository.set(data)
+        execution_time = (time.time() - start_time) * 1000
+
+        if result.get('status'):
+            logger_persistence.info(
+                f"💾 UPDATE PERSISTENCE | "
+                f"Table: samb_cronjobs | "
+                f"Project: {self.entity.get_project_name()} | "
+                f"Method: set_ejecution_repository | "
+                f"Cronjob ID: {data.get('id_cronjobs', 'N/A')} | "
+                f"Execution Time: {execution_time:.2f}ms | "
+                f"Status: SUCCESS"
+            )
+        else:
+            logger_persistence.error(
+                f"💾 UPDATE PERSISTENCE | "
+                f"Table: samb_cronjobs | "
+                f"Project: {self.entity.get_project_name()} | "
+                f"Method: set_ejecution_repository | "
+                f"Cronjob ID: {data.get('id_cronjobs', 'N/A')} | "
+                f"Execution Time: {execution_time:.2f}ms | "
+                f"Status: FAILED | "
+                f"Error: {result.get('message', 'Unknown error')}"
+            )
+
+        return result
     
     def set_ejecution(self,date,time_execution,id_cronjobs):
 

--- a/apis/services/entrys/ServicesEntrys.py
+++ b/apis/services/entrys/ServicesEntrys.py
@@ -5,6 +5,7 @@ import apis.entities.entrys.EntityEntrys as EntityEntrys
 import apis.repositories.entrys.RepositoryEntrys as RepositoryEntrys
 
 logger = logging.getLogger('apis.services.entrys')
+logger_persistence = logging.getLogger('ServicesPersistence')
 
 class ServicesEntrys():
 
@@ -74,34 +75,34 @@ class ServicesEntrys():
         account_id_broker  = contract_details.get('account_id', 'N/A')
 
         if result.get('status'):
-            logger.info(
-                f"⚡ ADD POSITIONS | "
+            logger_persistence.info(
+                f"💾 ADD PERSISTENCE | "
+                f"Table: samb_entrys | "
                 f"Project: {self.get_project_name()} | "
                 f"Method: add_entrys | "
                 f"Methodology: {data['id_methodology']} | "
                 f"Account: {data['mode']} | "
                 f"Position: {data['type_operations']} | "
-                f"Amount: ${data['amount']} | "
+                f"Stake: ${data['amount']} | "
                 f"Entry ID: {data['id_entry']} | "
-                f"contract_id_broker: {contract_id_broker} | "
-                f"account_id_broker: {account_id_broker} | "
-                f"Cronjob: {data['id_cronjobs']} | "
+                f"Contract ID: {contract_id_broker} | "
+                f"Cronjob ID: {data['id_cronjobs']} | "
                 f"Execution Time: {execution_time:.2f}ms | "
                 f"Status: SUCCESS"
             )
         else:
-            logger.error(
-                f"⚡ ADD POSITIONS | "
+            logger_persistence.error(
+                f"💾 ADD PERSISTENCE | "
+                f"Table: samb_entrys | "
                 f"Project: {self.get_project_name()} | "
                 f"Method: add_entrys | "
                 f"Methodology: {data['id_methodology']} | "
                 f"Account: {data['mode']} | "
                 f"Position: {data['type_operations']} | "
-                f"Amount: ${data['amount']} | "
+                f"Stake: ${data['amount']} | "
                 f"Entry ID: {data['id_entry']} | "
-                f"contract_id_broker: {contract_id_broker} | "
-                f"account_id_broker: {account_id_broker} | "
-                f"Cronjob: {data['id_cronjobs']} | "
+                f"Contract ID: {contract_id_broker} | "
+                f"Cronjob ID: {data['id_cronjobs']} | "
                 f"Execution Time: {execution_time:.2f}ms | "
                 f"Status: FAILED | "
                 f"Error: {result.get('message', 'Unknown error')}"

--- a/apis/services/entryspredictmodels/ServicesEntrysPredictModels.py
+++ b/apis/services/entryspredictmodels/ServicesEntrysPredictModels.py
@@ -2,6 +2,12 @@ import apis.repositories.entryspredictmodels.RepositoryEntrysPredictModels as Re
 
 import apis.entities.entryspredictmodels.EntityEntrysPredictModels as EntityEntrysPredictModels
 
+from decouple import config
+import logging
+import time
+
+logger = logging.getLogger('ServicesPersistence')
+
 class ServicesEntrysPredictModels: 
 
     ServicesDates = None   
@@ -49,7 +55,33 @@ class ServicesEntrysPredictModels:
 
         data_persistence = self.init_add(data)  
 
+        start_time = time.time()
         result = self.add_repository(data_persistence)
+        execution_time = (time.time() - start_time) * 1000
+
+        if result.get('status'):
+            logger.info(
+                f"💾 ADD PERSISTENCE | "
+                f"Table: samb_entrys_predict_models | "
+                f"Project: {config('PROJECT_NAME', default='N/A')} | "
+                f"Method: add | "
+                f"Entry ID: {data_persistence['id_entrys']} | "
+                f"Model ID: {data_persistence['id_predict_models']} | "
+                f"Execution Time: {execution_time:.2f}ms | "
+                f"Status: SUCCESS"
+            )
+        else:
+            logger.error(
+                f"💾 ADD PERSISTENCE | "
+                f"Table: samb_entrys_predict_models | "
+                f"Project: {config('PROJECT_NAME', default='N/A')} | "
+                f"Method: add | "
+                f"Entry ID: {data_persistence['id_entrys']} | "
+                f"Model ID: {data_persistence['id_predict_models']} | "
+                f"Execution Time: {execution_time:.2f}ms | "
+                f"Status: FAILED | "
+                f"Error: {result.get('msj', 'Unknown error')}"
+            )
 
         return result
         

--- a/apis/services/entrysresults/ServicesEntrysResults.py
+++ b/apis/services/entrysresults/ServicesEntrysResults.py
@@ -7,6 +7,7 @@ import re
 import uuid
 
 logger = logging.getLogger('apis.services.entrysresults')
+logger_persistence = logging.getLogger('ServicesPersistence')
 
 class ServicesEntrysResults():
 
@@ -99,30 +100,33 @@ class ServicesEntrysResults():
 
         result_entry = data_persistence['result_entry']
         win = result_entry > 0
+        contract_id = data.get('contract_details', {}).get('contract_id', 'N/A') if isinstance(data, dict) else 'N/A'
 
         if result.get('status'):
-            logger.info(
-                f"📝 ADD POSITIONS RESULT | "
+            logger_persistence.info(
+                f"💾 ADD PERSISTENCE | "
+                f"Table: samb_entrys_results | "
                 f"Project: {self.get_project_name()} | "
                 f"Method: add_persistence | "
                 f"Entry ID: {data_persistence['id_entry']} | "
                 f"Result ID: {data_persistence['id_entry_result']} | "
+                f"Contract ID: {contract_id} | "
                 f"Result: ${result_entry:.2f} | "
                 f"Win: {win} | "
-                f"Date: {data_persistence['current_date']} | "
                 f"Execution Time: {execution_time:.2f}ms | "
                 f"Status: SUCCESS"
             )
         else:
-            logger.error(
-                f"📝 ADD POSITIONS RESULT | "
+            logger_persistence.error(
+                f"💾 ADD PERSISTENCE | "
+                f"Table: samb_entrys_results | "
                 f"Project: {self.get_project_name()} | "
                 f"Method: add_persistence | "
                 f"Entry ID: {data_persistence['id_entry']} | "
                 f"Result ID: {data_persistence['id_entry_result']} | "
+                f"Contract ID: {contract_id} | "
                 f"Result: ${result_entry:.2f} | "
                 f"Win: {win} | "
-                f"Date: {data_persistence['current_date']} | "
                 f"Execution Time: {execution_time:.2f}ms | "
                 f"Status: FAILED | "
                 f"Error: {result.get('message', 'Unknown error')}"

--- a/apis/services/events/ServicesEvents.py
+++ b/apis/services/events/ServicesEvents.py
@@ -6,6 +6,7 @@ import apis.entities.events.EntityEvents as EntityEvents
 import apis.repositories.events.RepositoryEvents as RepositoryEvents
 
 logger = logging.getLogger('apis.services.events')
+logger_persistence = logging.getLogger('ServicesPersistence')
 
 class ServicesEvents():
 
@@ -77,7 +78,35 @@ class ServicesEvents():
 
         data = self.init_data_add_events(details,diferrences,id_cronjobs)
 
-        return self.add_events_repository(data)
+        start_time = time.time()
+        result = self.add_events_repository(data)
+        execution_time = (time.time() - start_time) * 1000
+
+        if result.get('status'):
+            logger_persistence.info(
+                f"💾 ADD PERSISTENCE | "
+                f"Table: samb_events | "
+                f"Project: {self.entity.get_project_name()} | "
+                f"Method: add_events | "
+                f"Event ID: {data['id']} | "
+                f"Cronjob ID: {id_cronjobs} | "
+                f"Execution Time: {execution_time:.2f}ms | "
+                f"Status: SUCCESS"
+            )
+        else:
+            logger_persistence.error(
+                f"💾 ADD PERSISTENCE | "
+                f"Table: samb_events | "
+                f"Project: {self.entity.get_project_name()} | "
+                f"Method: add_events | "
+                f"Event ID: {data['id']} | "
+                f"Cronjob ID: {id_cronjobs} | "
+                f"Execution Time: {execution_time:.2f}ms | "
+                f"Status: FAILED | "
+                f"Error: {result.get('msj', 'Unknown error')}"
+            )
+
+        return result
     
     def get_events_daily_cron_repository(self):
 

--- a/apis/services/framework/ServicesFramework.py
+++ b/apis/services/framework/ServicesFramework.py
@@ -1,5 +1,10 @@
 import apis.repositories.framework.RepositoryFramework as RepositoryFramework
 import apis.entities.framework.EntityFramework as EntityFramework
+from decouple import config
+import logging
+import time
+
+logger = logging.getLogger('ServicesPersistence')
 
 class ServicesFramework:
 
@@ -37,6 +42,30 @@ class ServicesFramework:
 
         data_persistence = await self.init_data_add()
 
+        start_time = time.time()
         result = await self.repository.add(data_persistence)
+        execution_time = (time.time() - start_time) * 1000
+
+        if result.get('status'):
+            logger.info(
+                f"💾 ADD PERSISTENCE | "
+                f"Table: samb_framework | "
+                f"Project: {config('PROJECT_NAME', default='N/A')} | "
+                f"Method: add | "
+                f"Framework ID: {data_persistence['id_framework']} | "
+                f"Execution Time: {execution_time:.2f}ms | "
+                f"Status: SUCCESS"
+            )
+        else:
+            logger.error(
+                f"💾 ADD PERSISTENCE | "
+                f"Table: samb_framework | "
+                f"Project: {config('PROJECT_NAME', default='N/A')} | "
+                f"Method: add | "
+                f"Framework ID: {data_persistence['id_framework']} | "
+                f"Execution Time: {execution_time:.2f}ms | "
+                f"Status: FAILED | "
+                f"Error: {result.get('message', 'Unknown error')}"
+            )
 
         return result

--- a/apis/services/indicatorsentrys/ServicesIndicatorsEntrys.py
+++ b/apis/services/indicatorsentrys/ServicesIndicatorsEntrys.py
@@ -1,5 +1,10 @@
 import apis.repositories.indicatorsentrys.RepositoryIndicatorsEntrys as RepositoryIndicatorsEntrys
 import apis.entities.indicatorsentrys.EntityIndicatorsEntrys as EntityIndicatorsEntrys
+from decouple import config
+import logging
+import time
+
+logger = logging.getLogger('ServicesPersistence')
 
 class ServicesIndicatorsEntrys():
 
@@ -69,6 +74,8 @@ class ServicesIndicatorsEntrys():
     def add_persistence(self, data):
 
         data_persistence = self.init_data_add_persistence(data)
+        entry_id = data.get('data_entry', {}).get('id_entry', 'N/A')
+        start_time = time.time()
 
         for key in data_persistence:
 
@@ -76,8 +83,34 @@ class ServicesIndicatorsEntrys():
 
             if not result['status']:
 
+                execution_time = (time.time() - start_time) * 1000
+                logger.error(
+                    f"💾 ADD PERSISTENCE | "
+                    f"Table: samb_indicators_entrys | "
+                    f"Project: {config('PROJECT_NAME', default='N/A')} | "
+                    f"Method: add_persistence | "
+                    f"Entry ID: {entry_id} | "
+                    f"Indicator: {key} | "
+                    f"Execution Time: {execution_time:.2f}ms | "
+                    f"Status: FAILED | "
+                    f"Error: {result.get('msj', 'Unknown error')}"
+                )
                 return False
-        
+
+        execution_time = (time.time() - start_time) * 1000
+        logger.info(
+            f"💾 ADD PERSISTENCE | "
+            f"Table: samb_indicators_entrys | "
+            f"Project: {config('PROJECT_NAME', default='N/A')} | "
+            f"Method: add_persistence | "
+            f"Entry ID: {entry_id} | "
+            f"RSI: {data.get('rsi', 'N/A')} | "
+            f"SMA10: {data.get('sma_short', 'N/A')} | "
+            f"SMA30: {data.get('sma_long', 'N/A')} | "
+            f"Execution Time: {execution_time:.2f}ms | "
+            f"Status: SUCCESS"
+        )
+
         return result
     
     def init_data_get_indicators_entrys(self, data):

--- a/apis/services/movements/ServicesMovements.py
+++ b/apis/services/movements/ServicesMovements.py
@@ -1,5 +1,10 @@
 import apis.repositories.movements.RepositoryMovements as RepositoryMovements
-import apis.entities.movements.EntityMovements as EntityMovements   
+import apis.entities.movements.EntityMovements as EntityMovements
+from decouple import config
+import logging
+import time
+
+logger = logging.getLogger('ServicesPersistence')
 
 class ServicesMovements():
 
@@ -54,7 +59,38 @@ class ServicesMovements():
 
         data_persistence = self.init_data_add_persistence(self.get_candles(),data)
 
-        return self.add_movements_repository(data_persistence)
+        start_time = time.time()
+        result = self.add_movements_repository(data_persistence)
+        execution_time = (time.time() - start_time) * 1000
+
+        entry_id = data.get('data_entry', {}).get('id_entry', 'N/A')
+        candles_count = len(data_persistence)
+
+        if result.get('status'):
+            logger.info(
+                f"💾 ADD PERSISTENCE | "
+                f"Table: samb_movements | "
+                f"Project: {config('PROJECT_NAME', default='N/A')} | "
+                f"Method: add_persistence | "
+                f"Entry ID: {entry_id} | "
+                f"Candles: {candles_count} | "
+                f"Execution Time: {execution_time:.2f}ms | "
+                f"Status: SUCCESS"
+            )
+        else:
+            logger.error(
+                f"💾 ADD PERSISTENCE | "
+                f"Table: samb_movements | "
+                f"Project: {config('PROJECT_NAME', default='N/A')} | "
+                f"Method: add_persistence | "
+                f"Entry ID: {entry_id} | "
+                f"Candles: {candles_count} | "
+                f"Execution Time: {execution_time:.2f}ms | "
+                f"Status: FAILED | "
+                f"Error: {result.get('message', 'Unknown error')}"
+            )
+
+        return result
     
     def init_data_get_movements_by_entry(self, entry):
 

--- a/apis/services/reports/ServicesReports.py
+++ b/apis/services/reports/ServicesReports.py
@@ -1,5 +1,10 @@
 import apis.entities.reports.EntityReports as EntityReports
-import apis.repositories.reports.RepositoryReports as RepositoryReports 
+import apis.repositories.reports.RepositoryReports as RepositoryReports
+from decouple import config
+import logging
+import time
+
+logger = logging.getLogger('ServicesPersistence')
 
 class ServicesReports():
 
@@ -38,4 +43,32 @@ class ServicesReports():
 
         data_peristence = self.init_data_add_persistence(type_reports,date)
 
-        return self.add_repository(data_peristence) 
+        start_time = time.time()
+        result = self.add_repository(data_peristence)
+        execution_time = (time.time() - start_time) * 1000
+
+        if result.get('status'):
+            logger.info(
+                f"💾 ADD PERSISTENCE | "
+                f"Table: samb_reports | "
+                f"Project: {config('PROJECT_NAME', default='N/A')} | "
+                f"Method: add_persistence | "
+                f"Report ID: {data_peristence['id']} | "
+                f"Type: {data_peristence['description']} | "
+                f"Execution Time: {execution_time:.2f}ms | "
+                f"Status: SUCCESS"
+            )
+        else:
+            logger.error(
+                f"💾 ADD PERSISTENCE | "
+                f"Table: samb_reports | "
+                f"Project: {config('PROJECT_NAME', default='N/A')} | "
+                f"Method: add_persistence | "
+                f"Report ID: {data_peristence['id']} | "
+                f"Type: {data_peristence['description']} | "
+                f"Execution Time: {execution_time:.2f}ms | "
+                f"Status: FAILED | "
+                f"Error: {result.get('msj', 'Unknown error')}"
+            )
+
+        return result

--- a/apis/services/sendentrys/ServicesSendEntrys.py
+++ b/apis/services/sendentrys/ServicesSendEntrys.py
@@ -2,6 +2,12 @@ import apis.entities.sendentrys.EntitySendEntrys as EntitySendEntrys
 
 import apis.repositories.sendentrys.RepositorySendEntrys as RepositorySendEntrys
 
+from decouple import config
+import logging
+import time
+
+logger = logging.getLogger('ServicesPersistence')
+
 class ServicesSendEntrys:
 
     services_dates = None 
@@ -67,6 +73,32 @@ class ServicesSendEntrys:
 
         data_persistence = self.init_data_add_send_entrys(data, result)
 
+        start_time = time.time()
         result = self.add_send_entrys_repository(data_persistence)
+        execution_time = (time.time() - start_time) * 1000
+
+        if result.get('status'):
+            logger.info(
+                f"💾 ADD PERSISTENCE | "
+                f"Table: samb_send_entrys | "
+                f"Project: {config('PROJECT_NAME', default='N/A')} | "
+                f"Method: add_send_entrys | "
+                f"Send ID: {data_persistence['id']} | "
+                f"Response: {data_persistence['response']} | "
+                f"Execution Time: {execution_time:.2f}ms | "
+                f"Status: SUCCESS"
+            )
+        else:
+            logger.error(
+                f"💾 ADD PERSISTENCE | "
+                f"Table: samb_send_entrys | "
+                f"Project: {config('PROJECT_NAME', default='N/A')} | "
+                f"Method: add_send_entrys | "
+                f"Send ID: {data_persistence['id']} | "
+                f"Response: {data_persistence['response']} | "
+                f"Execution Time: {execution_time:.2f}ms | "
+                f"Status: FAILED | "
+                f"Error: {result.get('msj', 'Unknown error')}"
+            )
 
         return result

--- a/dev/settings.py
+++ b/dev/settings.py
@@ -154,6 +154,15 @@ LOGGING = {
             'class': 'logging.StreamHandler',
             'formatter': 'verbose',
         },
+        'file_persistence': {
+            'level': 'INFO',
+            'class': 'logging.handlers.RotatingFileHandler',
+            'filename': '/var/log/samb/persistence.log',
+            'maxBytes': 10485760,
+            'backupCount': 5,
+            'formatter': 'verbose',
+            'encoding': 'utf-8',
+        },
     },
     'loggers': {
         'apis.entities.models.EntityModels': {
@@ -303,6 +312,11 @@ LOGGING = {
         },
         'ServicesAccountValidation': {
             'handlers': ['console'],
+            'level': 'INFO',
+            'propagate': False,
+        },
+        'ServicesPersistence': {
+            'handlers': ['file_persistence', 'console'],
             'level': 'INFO',
             'propagate': False,
         },


### PR DESCRIPTION
- Add structured logging  ADD/UPDATE PERSISTENCE to all 10 persistence services
- Unified logger ServicesPersistence  /var/log/samb/persistence.log
- Correlation model: contract_id (brokersamb_entrys) + id_entry (downstream tables)
- Refactor existing  ADD POSITIONS and  ADD POSITIONS RESULT logs
- Add file_persistence RotatingFileHandler to dev/settings.py
- Create /var/log/samb directory in Dockerfile
- Add fix report REPORTS/202603/FIX-20260317-ADD-PERSISTENCE-LOGGING.md

Services instrumented:
  samb_framework, samb_cronjobs (ADD+UPDATE), samb_entrys, samb_movements, samb_indicators_entrys, samb_entrys_results, samb_entrys_predict_models, samb_events, samb_reports, samb_send_entrys

No DB changes. No new env vars.