### PR TITLE
feat(logging): add dedicated broker interaction log (logs_deriv.log)

### DIFF
--- a/dev/settings.py
+++ b/dev/settings.py
@@ -172,6 +172,14 @@ LOGGING = {
             'formatter': 'verbose',
             'encoding': 'utf-8',
         },
+        # --- BROKER INTERACTIONS DEDICATED LOG (no rotation — append-only like persistence.log) ---
+        'file_deriv': {
+            'class': 'logging.FileHandler',
+            'filename': '/var/log/samb/logs_deriv.log',
+            'mode': 'a',
+            'formatter': 'verbose',
+            'encoding': 'utf-8',
+        },
     },
     'loggers': {
         'apis.entities.models.EntityModels': {
@@ -310,12 +318,12 @@ LOGGING = {
             'propagate': False,
         },
         'ServicesBrokerRequest': {
-            'handlers': ['console', 'file_response'],
+            'handlers': ['console', 'file_response', 'file_deriv'],
             'level': 'INFO',
             'propagate': False,
         },
         'ServicesBrokerResponse': {
-            'handlers': ['console', 'file_response'],
+            'handlers': ['console', 'file_response', 'file_deriv'],
             'level': 'INFO',
             'propagate': False,
         },


### PR DESCRIPTION
- Add FileHandler 'file_deriv' pointing to /var/log/samb/logs_deriv.log
- Mode append-only, no rotation (same policy as persistence.log)
- Wire file_deriv to ServicesBrokerResponse and ServicesBrokerRequest loggers
- response.log untouched — file_deriv is a mirror, not a replacement
- Fixes false orphan detection in dc_sec12_broker_sync caused by response.log rotation truncating BROKER RESPONSE CLOSE events before full-day grep reads. logs_deriv.log can now be read with cat (full file) ensuring BrokerRealCIDs == PersistRealCIDs